### PR TITLE
TST: add some tests for LoHa

### DIFF
--- a/.github/workflows/integrations_tests.yml
+++ b/.github/workflows/integrations_tests.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   run_transformers_integration_tests:
     strategy:
+      fail-fast: false
       matrix:
         transformers-version: ['main', 'latest']
     runs-on: ubuntu-latest
@@ -40,10 +41,11 @@ jobs:
 
       - name: Test transformers integration
         run: |
-          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/ && git log
+          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/ && git rev-parse HEAD
           RUN_SLOW=1 pytest tests/peft_integration/test_peft_integration.py
   run_diffusers_integration_tests:
     strategy:
+      fail-fast: false
       matrix:
         # For now diffusers integration is not on PyPI
         diffusers-version: ['main']
@@ -76,5 +78,5 @@ jobs:
 
       - name: Test diffusers integration
         run: |
-          cd .. && git clone https://github.com/huggingface/diffusers.git && cd diffusers/ && git log
+          cd .. && git clone https://github.com/huggingface/diffusers.git && cd diffusers/ && git rev-parse HEAD
           pytest tests/lora/test_lora_layers_peft.py

--- a/.github/workflows/integrations_tests.yml
+++ b/.github/workflows/integrations_tests.yml
@@ -32,15 +32,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[test]
-          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/ && git log
           if [ "${{ matrix.transformers-version }}" == "main" ]; then
-              pip install -e ".[dev]"
+              pip install -U git+https://github.com/huggingface/transformers.git
           else
               echo "Nothing to do as transformers latest already installed"
           fi
 
       - name: Test transformers integration
         run: |
+          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/ && git log
           RUN_SLOW=1 pytest tests/peft_integration/test_peft_integration.py
   run_diffusers_integration_tests:
     strategy:
@@ -67,13 +67,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[test]
-          cd .. && git clone https://github.com/huggingface/diffusers.git && cd diffusers/ && git log
+          
           if [ "${{ matrix.diffusers-version }}" == "main" ]; then
-              pip install -e ".[dev]"
+              pip install -U git+https://github.com/huggingface/diffusers.git
           else
               echo "Nothing to do as diffusers latest already installed"
           fi
 
       - name: Test diffusers integration
         run: |
+          cd .. && git clone https://github.com/huggingface/diffusers.git && cd diffusers/ && git log
           pytest tests/lora/test_lora_layers_peft.py

--- a/src/peft/tuners/ia3/__init__.py
+++ b/src/peft/tuners/ia3/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from peft.import_utils import is_bnb_available
+from peft.import_utils import is_bnb_4bit_available, is_bnb_available
 
 from .config import IA3Config
 from .layer import IA3Layer, Linear
@@ -27,3 +27,8 @@ if is_bnb_available():
     from .bnb import Linear8bitLt
 
     __all__ += ["Linear8bitLt"]
+
+if is_bnb_4bit_available():
+    from .bnb import Linear4bit
+
+    __all__ += ["Linear4bit"]

--- a/src/peft/tuners/ia3/bnb.py
+++ b/src/peft/tuners/ia3/bnb.py
@@ -16,61 +16,127 @@
 import bitsandbytes as bnb
 import torch
 
+from peft.import_utils import is_bnb_4bit_available, is_bnb_available
+
 from .layer import IA3Layer
 
 
-class Linear8bitLt(bnb.nn.Linear8bitLt, IA3Layer):
-    # (IA)^3 implemented in a dense layer
-    def __init__(
-        self,
-        adapter_name,
-        in_features,
-        out_features,
-        is_feedforward,
-        **kwargs,
-    ) -> None:
-        bnb.nn.Linear8bitLt.__init__(
+if is_bnb_available():
+
+    class Linear8bitLt(bnb.nn.Linear8bitLt, IA3Layer):
+        # (IA)^3 implemented in a dense layer
+        def __init__(
             self,
+            adapter_name,
             in_features,
             out_features,
-            bias=kwargs.get("bias", True),
-            has_fp16_weights=kwargs.get("has_fp16_weights", True),
-            memory_efficient_backward=kwargs.get("memory_efficient_backward", False),
-            threshold=kwargs.get("threshold", 0.0),
-            index=kwargs.get("index", None),
-        )
-        IA3Layer.__init__(self, in_features=in_features, out_features=out_features, is_feedforward=is_feedforward)
-        self.is_feedforward = is_feedforward
+            is_feedforward,
+            **kwargs,
+        ) -> None:
+            bnb.nn.Linear8bitLt.__init__(
+                self,
+                in_features,
+                out_features,
+                bias=kwargs.get("bias", True),
+                has_fp16_weights=kwargs.get("has_fp16_weights", True),
+                memory_efficient_backward=kwargs.get("memory_efficient_backward", False),
+                threshold=kwargs.get("threshold", 0.0),
+                index=kwargs.get("index", None),
+            )
+            IA3Layer.__init__(self, in_features=in_features, out_features=out_features, is_feedforward=is_feedforward)
+            self.is_feedforward = is_feedforward
 
-        # Freezing the pre-trained weight matrix
-        self.weight.requires_grad = False
+            # Freezing the pre-trained weight matrix
+            self.weight.requires_grad = False
 
-        init_ia3_weights = kwargs.pop("init_ia3_weights", True)
-        self.update_layer(adapter_name, init_ia3_weights)
-        self.set_adapter(adapter_name)
+            init_ia3_weights = kwargs.pop("init_ia3_weights", True)
+            self.update_layer(adapter_name, init_ia3_weights)
+            self.set_adapter(adapter_name)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if self.disable_adapters:
-            return super().forward(x)
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            if self.disable_adapters:
+                return super().forward(x)
 
-        ia3_scaling = 1
-        for active_adapter in self.active_adapters:
-            if active_adapter not in self.ia3_l.keys():
-                continue
-            ia3_scaling *= self.ia3_l[active_adapter].flatten()
+            ia3_scaling = 1
+            for active_adapter in self.active_adapters:
+                if active_adapter not in self.ia3_l.keys():
+                    continue
+                ia3_scaling *= self.ia3_l[active_adapter].flatten()
 
-        requires_conversion = (not torch.is_autocast_enabled()) and (x.dtype != torch.float32)
-        if requires_conversion:
-            x = x.float()
-        if self.is_feedforward:
-            result = super().forward(x * ia3_scaling)
-            expected_dtype = result.dtype
-        else:
-            result = super().forward(x)
-            expected_dtype = result.dtype
-            result = result * ia3_scaling
+            requires_conversion = (not torch.is_autocast_enabled()) and (x.dtype != torch.float32)
+            if requires_conversion:
+                x = x.float()
+            if self.is_feedforward:
+                result = super().forward(x * ia3_scaling)
+                expected_dtype = result.dtype
+            else:
+                result = super().forward(x)
+                expected_dtype = result.dtype
+                result = result * ia3_scaling
 
-        if requires_conversion:
-            result = result.to(expected_dtype)
+            if requires_conversion:
+                result = result.to(expected_dtype)
 
-        return result
+            return result
+
+
+if is_bnb_4bit_available():
+
+    class Linear4bit(bnb.nn.Linear4bit, IA3Layer):
+        # IA3 implemented in a dense layer
+        def __init__(
+            self,
+            adapter_name,
+            in_features,
+            out_features,
+            is_feedforward,
+            **kwargs,
+        ) -> None:
+            bnb.nn.Linear4bit.__init__(
+                self,
+                in_features,
+                out_features,
+                bias=kwargs.get("bias", True),
+                compute_dtype=kwargs.get("compute_dtype", torch.float32),
+                compress_statistics=kwargs.get("compress_statistics", True),
+                quant_type=kwargs.get("quant_type", "nf4"),
+            )
+            IA3Layer.__init__(self, in_features=in_features, out_features=out_features, is_feedforward=is_feedforward)
+            self.is_feedforward = is_feedforward
+
+            # Freezing the pre-trained weight matrix
+            self.weight.requires_grad = False
+
+            init_ia3_weights = kwargs.pop("init_ia3_weights", True)
+            self.update_layer(adapter_name, init_ia3_weights)
+            self.set_adapter(adapter_name)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            if self.disable_adapters:
+                return super().forward(x)
+
+            ia3_scaling = 1
+            for active_adapter in self.active_adapters:
+                if active_adapter not in self.ia3_l.keys():
+                    continue
+                ia3_scaling *= self.ia3_l[active_adapter].flatten()
+
+            requires_conversion = (not torch.is_autocast_enabled()) and (x.dtype != torch.float32)
+            if requires_conversion:
+                x = x.float()
+            if self.is_feedforward:
+                result = super().forward(x * ia3_scaling)
+                expected_dtype = result.dtype
+            else:
+                result = super().forward(x)
+                expected_dtype = result.dtype
+                result = result * ia3_scaling
+
+            result = result.clone()
+            # adalora.py and lora.py both suggest that this is necessary for 4-bit training on older versions of Pytorch.
+            # This has been duplicated here.
+
+            if requires_conversion:
+                result = result.to(expected_dtype)
+
+            return result

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -23,7 +23,7 @@ from parameterized import parameterized
 from torch import nn
 from transformers.pytorch_utils import Conv1D
 
-from peft import AdaLoraConfig, IA3Config, LoraConfig, LoHaConfig, PeftModel, get_peft_model
+from peft import AdaLoraConfig, IA3Config, LoHaConfig, LoraConfig, PeftModel, get_peft_model
 
 from .testing_common import PeftCommonTester
 from .testing_utils import get_state_dict
@@ -54,7 +54,6 @@ TEST_CASES = [
     ("Embedding + transformers Conv1D 3", "EmbConv1D", LoraConfig, {"target_modules": ["emb", "conv1d"]}),
     ("Conv2d 1", "Conv2d", LoraConfig, {"target_modules": ["conv2d"]}),
     ("Conv2d 2", "Conv2d", LoraConfig, {"target_modules": ["conv2d", "lin0"]}),
-
     # LoHa
     ("Vanilla MLP 1 LOHA", "MLP", LoHaConfig, {"target_modules": "lin0"}),
     ("Vanilla MLP 2 LOHA", "MLP", LoHaConfig, {"target_modules": ["lin0"]}),
@@ -73,7 +72,6 @@ TEST_CASES = [
     ),
     ("Conv2d 1 LOHA", "Conv2d", LoHaConfig, {"target_modules": ["conv2d"]}),
     ("Conv2d 2 LOHA", "Conv2d", LoHaConfig, {"target_modules": ["conv2d", "lin0"]}),
-
 ]
 
 PREFIXES = {

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -23,7 +23,7 @@ from parameterized import parameterized
 from torch import nn
 from transformers.pytorch_utils import Conv1D
 
-from peft import AdaLoraConfig, IA3Config, LoraConfig, PeftModel, get_peft_model
+from peft import AdaLoraConfig, IA3Config, LoraConfig, LoHaConfig, PeftModel, get_peft_model
 
 from .testing_common import PeftCommonTester
 from .testing_utils import get_state_dict
@@ -33,6 +33,7 @@ from .testing_utils import get_state_dict
 # EmbConv1D has an embedding and a Conv1D layer
 # Conv2D has a Conv2D layer
 TEST_CASES = [
+    # LoRA
     ("Vanilla MLP 1", "MLP", LoraConfig, {"target_modules": "lin0"}),
     ("Vanilla MLP 2", "MLP", LoraConfig, {"target_modules": ["lin0"]}),
     ("Vanilla MLP 3", "MLP", LoraConfig, {"target_modules": ["lin1"]}),
@@ -53,7 +54,32 @@ TEST_CASES = [
     ("Embedding + transformers Conv1D 3", "EmbConv1D", LoraConfig, {"target_modules": ["emb", "conv1d"]}),
     ("Conv2d 1", "Conv2d", LoraConfig, {"target_modules": ["conv2d"]}),
     ("Conv2d 2", "Conv2d", LoraConfig, {"target_modules": ["conv2d", "lin0"]}),
+
+    # LoHa
+    ("Vanilla MLP 1 LOHA", "MLP", LoHaConfig, {"target_modules": "lin0"}),
+    ("Vanilla MLP 2 LOHA", "MLP", LoHaConfig, {"target_modules": ["lin0"]}),
+    ("Vanilla MLP 3 LOHA", "MLP", LoHaConfig, {"target_modules": ["lin1"]}),
+    ("Vanilla MLP 4 LOHA", "MLP", LoHaConfig, {"target_modules": ["lin0", "lin1"]}),
+    ("Vanilla MLP 5 LOHA", "MLP", LoHaConfig, {"target_modules": ["lin0"], "modules_to_save": ["lin1"]}),
+    (
+        "Vanilla MLP 6 LOHA",
+        "MLP",
+        LoHaConfig,
+        {
+            "target_modules": ["lin0"],
+            "alpha": 4,
+            "module_dropout": 0.1,
+        },
+    ),
+    ("Conv2d 1 LOHA", "Conv2d", LoHaConfig, {"target_modules": ["conv2d"]}),
+    ("Conv2d 2 LOHA", "Conv2d", LoHaConfig, {"target_modules": ["conv2d", "lin0"]}),
+
 ]
+
+PREFIXES = {
+    LoraConfig: "lora_",
+    LoHaConfig: "hada_",
+}
 
 
 class MLP(nn.Module):
@@ -233,9 +259,11 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         params_before = dict(model_before.named_parameters())
         params_after = dict(model.named_parameters())
         self.assertEqual(params_before.keys(), params_after.keys())
+
+        prefix = PREFIXES[config_cls]
         for name, param_before in params_before.items():
             param_after = params_after[name]
-            if ("lora_" in name) or ("modules_to_save" in name):
+            if (prefix in name) or ("modules_to_save" in name):
                 # target_modules and modules_to_save _are_ updated
                 self.assertFalse(torch.allclose(param_before, param_after, atol=tol, rtol=tol))
             else:
@@ -324,6 +352,9 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
 
         # Note: We test only with custom models since they run really fast. There is really no point in testing the same
         # thing with decoder, encoder_decoder, etc.
+        if config_cls != LoraConfig:
+            # skip this test for other configs as bias is specific to Lora
+            self.skipTest("Testing bias warnings only for LoraConfig")
 
         def run_with_disable(config_kwargs, bias):
             config_kwargs = config_kwargs.copy()


### PR DESCRIPTION
This PR adds the first couple of tests for LoHa by using the custom model tests. Eventually, we should also add the tests for (encoder) decoder, feature extraction, and stable diffusion. But I think it's good to have something to start quickly.

The PR also contains a few new methods that need to be added to the `LohaModel`.

Unfortunately, even though I branched off of the LoHa-branch, this PR still contains extra commits from main. Please ignore those. The relevant code is `loha/model.py` and `tests/test_custom_models.py`.

Ping @kovalexal 